### PR TITLE
Poisonning

### DIFF
--- a/src/container/concurrent/sequential.rs
+++ b/src/container/concurrent/sequential.rs
@@ -96,28 +96,34 @@ where
 
     /// Unwrap concurrent sequential and return wrapped container.
     pub fn unwrap(self) -> C {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         self.container
     }
 
     /// Lock the container for shared access.
     pub fn lock(&self) {
-        self.lock.lock()
+        self.lock.lock().unwrap()
     }
 
     /// Lock the container for exclusive access.
     pub fn lock_mut(&self) {
-        self.lock.lock_mut()
+        self.lock.lock_mut().unwrap()
     }
 
     /// Lock the container for shared access.
     pub fn try_lock(&self) -> bool {
-        self.lock.try_lock()
+        match self.lock.try_lock() {
+            Err(_) => false,
+            Ok(_) => true,
+        }
     }
 
     /// Lock the container for exclusive access.
     pub fn try_lock_mut(&self) -> bool {
-        self.lock.try_lock_mut()
+        match self.lock.try_lock_mut() {
+            Err(_) => false,
+            Ok(_) => true,
+        }
     }
 
     /// Unlock the container.
@@ -133,48 +139,48 @@ where
     C: Container<K, V, R>,
 {
     fn capacity(&self) -> usize {
-        self.lock.lock();
+        self.lock.lock().unwrap();
         let c = self.container.capacity();
         self.lock.unlock();
         c
     }
 
     fn count(&self) -> usize {
-        self.lock.lock();
+        self.lock.lock().unwrap();
         let c = self.container.count();
         self.lock.unlock();
         c
     }
 
     fn contains(&self, key: &K) -> bool {
-        self.lock.lock();
+        self.lock.lock().unwrap();
         let c = self.container.contains(key);
         self.lock.unlock();
         c
     }
 
     fn clear(&mut self) {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         self.container.clear();
         self.lock.unlock();
     }
 
     fn take(&mut self, key: &K) -> Option<R> {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         let ret = self.container.take(key);
         self.lock.unlock();
         ret
     }
 
     fn pop(&mut self) -> Option<(K, R)> {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         let v = self.container.pop();
         self.lock.unlock();
         v
     }
 
     fn push(&mut self, key: K, reference: R) -> Option<(K, R)> {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         let v = self.container.push(key, reference);
         self.lock.unlock();
         v
@@ -220,7 +226,7 @@ where
     C: Container<K, V, R> + Seq<K, V, R>,
 {
     fn get(&mut self, key: &K) -> Option<RWLockGuard<&V>> {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         match self.container.get(key) {
             None => {
                 self.lock.unlock();
@@ -231,7 +237,7 @@ where
     }
 
     fn get_mut(&mut self, key: &K) -> Option<RWLockGuard<&mut V>> {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         match self.container.get_mut(key) {
             None => {
                 self.lock.unlock();
@@ -256,7 +262,7 @@ where
     type Item = (K, V);
     type IntoIter = I;
     fn into_iter(self) -> Self::IntoIter {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         self.container.into_iter()
     }
 }
@@ -284,7 +290,7 @@ where
     type Iterator = SequentialIter<'a, I>;
 
     fn iter(&'a mut self) -> Self::Iterator {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         SequentialIter {
             it: self.container.iter(),
             _guard: RWLockGuard::new(&self.lock, true),
@@ -303,7 +309,7 @@ where
     type Iterator = SequentialIter<'a, I>;
 
     fn iter_mut(&'a mut self) -> Self::Iterator {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         SequentialIter {
             it: self.container.iter_mut(),
             _guard: RWLockGuard::new(&self.lock, true),

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -357,7 +357,7 @@ impl<V> RWLockCell<V> {
 
 #[cfg(test)]
 mod tests {
-    use super::{RWLock, TryLockError};
+    use super::{LockError, RWLock, TryLockError};
     use std::thread;
     use std::thread::JoinHandle;
 
@@ -416,6 +416,11 @@ mod tests {
 
         match lock.try_lock() {
             Err(TryLockError::Poisoned(_)) => {} // Ok
+            _ => panic!("Lock should be poisoned."),
+        }
+
+        match lock.lock() {
+            Err(LockError::Poisoned(_)) => {} // Ok
             _ => panic!("Lock should be poisoned."),
         }
     }

--- a/src/utils/stats.rs
+++ b/src/utils/stats.rs
@@ -86,41 +86,32 @@ impl SyncOnlineStats {
     /// After update, variance, mean etc... account for all elements,
     /// provided through this method.
     pub fn push(&mut self, x: f64) {
-        self.lock.lock_mut().unwrap();
-        self.stats.push(x);
-        self.lock.unlock();
+        let _ = self.lock.lock_mut_for(()).unwrap();
+        self.stats.push(x)
     }
 
     /// Return the maximum of elements pushed with `push` method.
     pub fn max(&self) -> f64 {
-        self.lock.lock().unwrap();
-        let x = self.stats.max();
-        self.lock.unlock();
-        x
+        let _ = self.lock.lock_for(()).unwrap();
+        self.stats.max()
     }
 
     /// Return the minimum of elements pushed with `push` method.
     pub fn min(&self) -> f64 {
-        self.lock.lock().unwrap();
-        let x = self.stats.min();
-        self.lock.unlock();
-        x
+        let _ = self.lock.lock_for(()).unwrap();
+        self.stats.min()
     }
 
     /// Return the mean of elements pushed with `push` method.
     pub fn mean(&self) -> f64 {
-        self.lock.lock().unwrap();
-        let x = self.stats.mean();
-        self.lock.unlock();
-        x
+        let _ = self.lock.lock_for(()).unwrap();
+        self.stats.mean()
     }
 
     /// Return the variance of elements pushed with `push` method.
     pub fn var(&self) -> f64 {
-        self.lock.lock().unwrap();
-        let x = self.stats.var();
-        self.lock.unlock();
-        x
+        let _ = self.lock.lock_for(()).unwrap();
+        self.stats.var()
     }
 }
 

--- a/src/utils/stats.rs
+++ b/src/utils/stats.rs
@@ -86,14 +86,14 @@ impl SyncOnlineStats {
     /// After update, variance, mean etc... account for all elements,
     /// provided through this method.
     pub fn push(&mut self, x: f64) {
-        self.lock.lock_mut();
+        self.lock.lock_mut().unwrap();
         self.stats.push(x);
         self.lock.unlock();
     }
 
     /// Return the maximum of elements pushed with `push` method.
     pub fn max(&self) -> f64 {
-        self.lock.lock();
+        self.lock.lock().unwrap();
         let x = self.stats.max();
         self.lock.unlock();
         x
@@ -101,7 +101,7 @@ impl SyncOnlineStats {
 
     /// Return the minimum of elements pushed with `push` method.
     pub fn min(&self) -> f64 {
-        self.lock.lock();
+        self.lock.lock().unwrap();
         let x = self.stats.min();
         self.lock.unlock();
         x
@@ -109,7 +109,7 @@ impl SyncOnlineStats {
 
     /// Return the mean of elements pushed with `push` method.
     pub fn mean(&self) -> f64 {
-        self.lock.lock();
+        self.lock.lock().unwrap();
         let x = self.stats.mean();
         self.lock.unlock();
         x
@@ -117,7 +117,7 @@ impl SyncOnlineStats {
 
     /// Return the variance of elements pushed with `push` method.
     pub fn var(&self) -> f64 {
-        self.lock.lock();
+        self.lock.lock().unwrap();
         let x = self.stats.var();
         self.lock.unlock();
         x

--- a/tests/concurrent/clone.rs
+++ b/tests/concurrent/clone.rs
@@ -31,7 +31,7 @@ impl<V> CloneCell<V> {
     pub fn new(value: V) -> Self {
         let rc = RWLock::new();
         // Increment reference count in the lock by one.
-        rc.lock();
+        rc.lock().unwrap();
         CloneCell {
             value: value,
             rc: rc,
@@ -39,12 +39,15 @@ impl<V> CloneCell<V> {
     }
 
     pub fn clone(&self) {
-        self.rc.lock();
+        self.rc.lock().unwrap();
     }
 
     pub fn drop(&mut self) -> bool {
         self.rc.unlock(); // release (last?) read lock.
-        self.rc.try_lock_mut() // Return whether we are the only remaining clone owner.
+        match self.rc.try_lock_mut() {
+            Ok(_) => true,
+            _ => false,
+        } // Return whether we are the only remaining clone owner.
     }
 }
 


### PR DESCRIPTION
Add Lock poisonning in the interface.
Concurrent containers will panic if their lock is poisonned.