### PR TITLE
Split Get and GetMut traits.

### DIFF
--- a/src/container/array.rs
+++ b/src/container/array.rs
@@ -1,4 +1,4 @@
-use crate::{BuildingBlock, Get, Ordered};
+use crate::{BuildingBlock, Get, GetMut, Ordered};
 use std::cmp::Eq;
 use std::ops::{Deref, DerefMut};
 use std::vec::Vec;
@@ -167,7 +167,7 @@ impl<T> DerefMut for ArrayMutCell<T> {
     }
 }
 
-impl<K: Eq, V> Get<K, V, ArrayCell<V>, ArrayMutCell<V>> for Array<(K, V)> {
+impl<K: Eq, V> Get<K, V, ArrayCell<V>> for Array<(K, V)> {
     /// Get value inside a `Array`. The value is wrapped inside a
     /// [`ArrayCell`](struct.ArrayCell.html). The `ArrayCell` can
     /// further be dereferenced into a value reference.
@@ -209,7 +209,9 @@ impl<K: Eq, V> Get<K, V, ArrayCell<V>, ArrayMutCell<V>> for Array<(K, V)> {
             }
         })
     }
+}
 
+impl<K: Eq, V> GetMut<K, V, ArrayMutCell<V>> for Array<(K, V)> {
     /// Get value inside a `Array`. The value is wrapped inside a
     /// [`ArrayMutCell`](struct.ArrayMutCell.html). The `ArrayMutCell`
     /// can further be dereferenced into a value reference.
@@ -225,7 +227,7 @@ impl<K: Eq, V> Get<K, V, ArrayCell<V>, ArrayMutCell<V>> for Array<(K, V)> {
     /// ## Example:
     ///
     /// ```
-    /// use cache::{BuildingBlock, Get};
+    /// use cache::{BuildingBlock, GetMut};
     /// use cache::container::Array;
     ///
     /// // Make a array and populate it.
@@ -252,7 +254,6 @@ impl<K: Eq, V> Get<K, V, ArrayCell<V>, ArrayMutCell<V>> for Array<(K, V)> {
         })
     }
 }
-
 //------------------------------------------------------------------------//
 //  Tests
 //------------------------------------------------------------------------//
@@ -261,7 +262,7 @@ impl<K: Eq, V> Get<K, V, ArrayCell<V>, ArrayMutCell<V>> for Array<(K, V)> {
 mod tests {
     use super::Array;
     use crate::policy::tests::test_ordered;
-    use crate::tests::{test_building_block, test_get};
+    use crate::tests::{test_building_block, test_get, test_get_mut};
 
     #[test]
     fn building_block() {
@@ -282,5 +283,8 @@ mod tests {
         test_get(Array::new(0));
         test_get(Array::new(10));
         test_get(Array::new(100));
+        test_get_mut(Array::new(0));
+        test_get_mut(Array::new(10));
+        test_get_mut(Array::new(100));
     }
 }

--- a/src/container/stream/stream.rs
+++ b/src/container/stream/stream.rs
@@ -1,7 +1,7 @@
 use crate::container::stream::io_vec::{IOStruct, IOStructMut, IOVec};
 use crate::container::stream::{Stream, StreamFactory};
 use crate::private::set::MinSet;
-use crate::{BuildingBlock, Get, Ordered};
+use crate::{BuildingBlock, Get, GetMut, Ordered};
 use serde::{de::DeserializeOwned, Serialize};
 use std::ops::{Deref, DerefMut};
 
@@ -331,8 +331,7 @@ where
     }
 }
 
-impl<K, V, F, S> Get<K, V, StreamCell<K, V>, StreamMutCell<K, V, S>>
-    for ByteStream<(K, V), S, F>
+impl<K, V, F, S> Get<K, V, StreamCell<K, V>> for ByteStream<(K, V), S, F>
 where
     K: DeserializeOwned + Serialize + Eq,
     V: DeserializeOwned + Serialize,
@@ -388,7 +387,16 @@ where
                 })
             })
     }
+}
 
+impl<K, V, F, S> GetMut<K, V, StreamMutCell<K, V, S>>
+    for ByteStream<(K, V), S, F>
+where
+    K: DeserializeOwned + Serialize + Eq,
+    V: DeserializeOwned + Serialize,
+    S: Stream,
+    F: StreamFactory<S> + Clone,
+{
     /// Get a mutable value inside a `ByteStream`. The value is wrapped
     /// inside a [`StreamMutCell`](struct.StreamMutCell.html).
     /// The `StreamMutCell` can further be dereferenced into a value
@@ -406,7 +414,7 @@ where
     /// ## Example:
     ///
     /// ```
-    /// use cache::{BuildingBlock, Get};
+    /// use cache::{BuildingBlock, Get, GetMut};
     /// use cache::container::ByteStream;
     /// use cache::container::stream::vec_stream::VecStreamFactory;
     ///
@@ -452,7 +460,7 @@ mod tests {
     use super::ByteStream;
     use crate::container::stream::vec_stream::VecStreamFactory;
     use crate::policy::tests::test_ordered;
-    use crate::tests::{test_building_block, test_get};
+    use crate::tests::{test_building_block, test_get, test_get_mut};
 
     #[test]
     fn building_block() {
@@ -472,6 +480,7 @@ mod tests {
     fn get() {
         for i in vec![0, 10, 100] {
             test_get(ByteStream::new(VecStreamFactory {}, i));
+            test_get_mut(ByteStream::new(VecStreamFactory {}, i));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,13 +81,18 @@ pub trait BuildingBlock<'a, K: 'a, V: 'a> {
 /// implementation maybe `unsafe`, because the returned guard lifetime
 /// may outlive the borrowing lifetime of the container where the inner
 /// value originates from.
-pub trait Get<K, V, U, W>
+pub trait Get<K, V, U>
 where
     U: Deref<Target = V>,
-    W: Deref<Target = V> + DerefMut,
 {
     /// Get a read-only smart pointer to a value inside the container.
     unsafe fn get(&self, key: &K) -> Option<U>;
+}
+
+pub trait GetMut<K, V, W>
+where
+    W: Deref<Target = V> + DerefMut,
+{
     /// Get a smart pointer to a mutable value inside the container.
     unsafe fn get_mut(&mut self, key: &K) -> Option<W>;
 }

--- a/src/private/clone.rs
+++ b/src/private/clone.rs
@@ -1,5 +1,5 @@
 use crate::private::lock::RWLock;
-use crate::{BuildingBlock, Concurrent, Get, Ordered};
+use crate::{BuildingBlock, Concurrent, Get, GetMut, Ordered};
 use std::boxed::Box;
 use std::marker::Sync;
 use std::ops::{Deref, DerefMut, Drop};
@@ -185,16 +185,21 @@ impl<V: Ord, C: Ordered<V>> Ordered<V> for CloneCell<C> {}
 // Get trait implementation
 //------------------------------------------------------------------------//
 
-impl<K, V, C, U, W> Get<K, V, U, W> for CloneCell<C>
+impl<K, V, C, U> Get<K, V, U> for CloneCell<C>
 where
     U: Deref<Target = V>,
-    W: Deref<Target = V> + DerefMut,
-    C: Get<K, V, U, W>,
+    C: Get<K, V, U>,
 {
     unsafe fn get(&self, key: &K) -> Option<U> {
         self.deref().get(key)
     }
+}
 
+impl<K, V, C, W> GetMut<K, V, W> for CloneCell<C>
+where
+    W: Deref<Target = V> + DerefMut,
+    C: GetMut<K, V, W>,
+{
     unsafe fn get_mut(&mut self, key: &K) -> Option<W> {
         self.deref_mut().get_mut(key)
     }

--- a/src/private/ptr.rs
+++ b/src/private/ptr.rs
@@ -1,4 +1,5 @@
 use std::cmp::{Ord, Ordering};
+use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
 //-------------------------------------------------------------------------//
@@ -22,6 +23,19 @@ impl<T: Ord> OrdPtr<T> {
         OrdPtr {
             ptr: NonNull::<T>::from(value),
         }
+    }
+}
+
+impl<T: Ord> Deref for OrdPtr<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T: Ord> DerefMut for OrdPtr<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { self.ptr.as_mut() }
     }
 }
 

--- a/src/profiler/profiler.rs
+++ b/src/profiler/profiler.rs
@@ -1,5 +1,5 @@
 use crate::private::clone::CloneCell;
-use crate::{BuildingBlock, Concurrent, Get, Ordered};
+use crate::{BuildingBlock, Concurrent, Get, GetMut, Ordered};
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
@@ -347,11 +347,10 @@ where
 // Get trait implementation
 //------------------------------------------------------------------------//
 
-impl<K, V, U, W, C> Get<K, V, U, W> for Profiler<C>
+impl<K, V, U, C> Get<K, V, U> for Profiler<C>
 where
     U: Deref<Target = V>,
-    W: DerefMut<Target = V>,
-    C: Get<K, V, U, W>,
+    C: Get<K, V, U>,
 {
     unsafe fn get(&self, key: &K) -> Option<U> {
         let (time, out) = time_it!(self.cache.get(key));
@@ -364,7 +363,13 @@ where
         };
         out
     }
+}
 
+impl<K, V, W, C> GetMut<K, V, W> for Profiler<C>
+where
+    W: DerefMut<Target = V>,
+    C: GetMut<K, V, W>,
+{
     unsafe fn get_mut(&mut self, key: &K) -> Option<W> {
         let (time, out) = time_it!(self.cache.get_mut(key));
         self.stats.get_mut.add(1, time);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
 extern crate rand;
-use crate::{BuildingBlock, Get};
+use crate::{BuildingBlock, Get, GetMut};
 use rand::random;
 use std::ops::{Deref, DerefMut};
 
@@ -50,11 +50,24 @@ where
     (inserted, out)
 }
 
-pub fn test_get<'a, C, U, W>(mut c: C)
+pub fn test_get<'a, C, U>(mut c: C)
 where
     U: Deref<Target = u32>,
+    C: 'a + BuildingBlock<'a, u16, u32> + Get<u16, u32, U>,
+{
+    let elements: Vec<(u16, u32)> =
+        (0u16..10u16).map(|i| (i, i as u32)).collect();
+    let (elements, _) = insert(&mut c, elements);
+
+    for (k, _) in elements.iter() {
+        assert!(unsafe { c.get(k) }.is_some());
+    }
+}
+
+pub fn test_get_mut<'a, C, W>(mut c: C)
+where
     W: Deref<Target = u32> + DerefMut,
-    C: 'a + BuildingBlock<'a, u16, u32> + Get<u16, u32, U, W>,
+    C: 'a + BuildingBlock<'a, u16, u32> + GetMut<u16, u32, W>,
 {
     let elements: Vec<(u16, u32)> =
         (0u16..10u16).map(|i| (i, i as u32)).collect();
@@ -66,7 +79,7 @@ where
     }
 
     for (k, v) in elements.iter() {
-        assert_eq!(*unsafe { c.get(k).unwrap() } as u32, *v + 1u32);
+        assert_eq!(*unsafe { c.get_mut(k).unwrap() } as u32, *v + 1u32);
     }
 }
 


### PR DESCRIPTION
This enables implementation of GetMut for BTree
and different trait bounds for GetMut and Get in Forward.